### PR TITLE
Multiple fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+local/

--- a/apriori.py
+++ b/apriori.py
@@ -1,18 +1,21 @@
 from efficient_apriori import apriori
 
-
 class Apriori:
-    def __init__(self, transactions, support=0.5, confidence=0.5):
+    def __init__(self, transactions, support=0.5, confidence=0.5, max_length=8):
         self.transactions = transactions
         self.support = support
         self.confidence = confidence
+        self.max_length = max_length
 
     def set_support(self, support):
         self.support = support
 
     def set_confidence(self, confidence):
         self.confidence = confidence
+        
+    def set_max_length(self, max_length):
+        self.max_length = max_length
 
     def get_rules(self):
-        _, rules = apriori(self.transactions, min_support=self.support, min_confidence=self.confidence)
+        _, rules = apriori(self.transactions, min_support=self.support, min_confidence=self.confidence, max_length=self.max_length)
         return rules

--- a/main.py
+++ b/main.py
@@ -27,8 +27,8 @@ def main():
     args = p.parse_args()
     confidence = float(args.confidence)
     support = float(args.support)
-    max_length = float(args.max_length)
-    print("Apriori (support=%.3f, confidence=%.3f)" % (support, confidence))
+    max_length = int(args.max_length)
+    print("Apriori (support=%.3f, confidence=%.3f, max_length=%d)" % (support, confidence, max_length))
     
     gitpy = git.Git(CLONE_PATH)
 

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from parsers.java import JavaParser
 from parsers.python import PythonParser
 from settings import CLONE_PATH
 from utils.utils import generate_hash
+from utils.utils import get_commit_count
 
 p = argparse.ArgumentParser(description="Prepare something code.")
 p.add_argument("-r", "--repository", help="Remote Git repository", required=False)
@@ -20,13 +21,15 @@ p.add_argument("-d", "--dir", help="Local project directory", required=False)
 p.add_argument("-l", "--lang", help="Programming language", choices=['python', 'java', 'go'], required=True)
 p.add_argument("-s", "--support", help="correlation support value", default=0.5)
 p.add_argument("-c", "--confidence", help="correlation support value", default=0.5)
-
+p.add_argument("-L", "--max_length", help="max number of items in a rule", default=2)
 
 def main():
     args = p.parse_args()
     confidence = float(args.confidence)
     support = float(args.support)
-    print("Apriori (support=%.2f, confidence=%.2f)" % (confidence, support))
+    max_length = float(args.max_length)
+    print("Apriori (support=%.3f, confidence=%.3f)" % (support, confidence))
+    
     gitpy = git.Git(CLONE_PATH)
 
     # fetching repository / folder
@@ -37,6 +40,9 @@ def main():
         print("Cloning repository to %s..." % project_path)
         gitpy.clone(args.repository, project_folder)
 
+    print("number of commits: %d" % (get_commit_count(project_path)))
+    print("support absolute value: %d" % (support * get_commit_count(project_path)))
+    
     # defining language parser
     parser = BaseParser
     if args.lang == "go":
@@ -45,18 +51,26 @@ def main():
         parser = JavaParser
     elif args.lang == "python":
         parser = PythonParser
-
+    
     print("parsing project...")
+    
     function_changes = []
     for commit in RepositoryMining(project_path).traverse_commits():
         language_parser = parser(project_path, commit.hash)
         changes = language_parser.get_diff()
         if changes:
             function_changes.append(changes)
-
+            
+    print("Transactions:")
+    for changes in function_changes:
+        print(changes)
+    
     print("analyzing transactions...")
-    apriori = Apriori(function_changes, confidence=float(args.confidence), support=float(args.support))
+    
+    apriori = Apriori(function_changes, confidence=float(confidence), support=float(support), max_length=int(max_length))
     rules = apriori.get_rules()
+    
+    print("Association rules:")
     for rule in rules:
         print(rule)
 

--- a/parsers/base.py
+++ b/parsers/base.py
@@ -36,6 +36,7 @@ class BaseParser:
             group_changes = []
             if file_name and functions_changed:
                 for function in functions_changed:
+                    #diffs.append("[%s] %s" % (file_name, function))
                     group_changes.append("[%s] %s" % (file_name, function))
 
                 diffs.append(tuple(group_changes))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -1,6 +1,13 @@
 import hashlib
 import os
+from pydriller import RepositoryMining
 
 
 def generate_hash(size=8):
     return hashlib.md5(os.urandom(32)).hexdigest()[:size]
+
+def get_commit_count(project_path):
+    result = 0
+    for commit in RepositoryMining(project_path).traverse_commits():
+        result += 1
+    return result


### PR DESCRIPTION
Summary

- Fixed output from BaseParser.get_diff(...)
- Added optional max_length parameter, which is the max number of items in a rule
- Fixed print(...) arguments order
- Added 'local/' to .gitignore
- Added function get_commit_count(...)
- Printing absolute support value

Since the output of BaseParser.get_diff(...) is used to form the input of Apriori.get_rules(), the
output of get_diff(...) was incorrect. `get_rules()` expects a 'list of lists', but get_diff(...) 
returns a 'list of list of tuples' like this (the following is ONE list of tuples, the output of get_diff(...) is a list of lists like this one):

[
  ('[doc.go] main',), 
  ('[mux.go] main', '[mux.go] init', '[mux.go] setVars', '[mux.go] setCurrentRoute', '[mux.go] mapFromPairs'), 
  ('[regexp.go] newRouteRegexp', '[regexp.go] braceIndices')
]

We cannot group changes in the same file in a tuple. The get_rules(...) would interpret each
tuple in this list as being an item of the transaction, but as you can see the second item contains 
in fact multiple items (that happened in the same file, but multiple items nonetheless). 
The correct input of a single transaction for get_rules for this same example is this:

[
  '[doc.go] main', 
  '[mux.go] main', 
  '[mux.go] init', 
  '[mux.go] setVars', 
  '[mux.go] setCurrentRoute', 
  '[mux.go] mapFromPairs', 
  '[regexp.go] newRouteRegexp', 
  '[regexp.go] braceIndices'
]
